### PR TITLE
minor additions to 0.9.0

### DIFF
--- a/R/citation_search.R
+++ b/R/citation_search.R
@@ -12,24 +12,17 @@
 #' }
 citation_search <- function(identifiers,
                             sources = c("plos", "scopus", "springer")) {
+  
+  # run the 'citation_search_*' function for each source
+  for (source in sources) {
+    search_function <- paste0(source, " <- citation_search_", source, "(identifiers)")
+    eval(parse(text = search_function))
+  }
 
-    if (any(!grepl("10\\.|urn:uuid", identifiers))){
-        warning(call. = FALSE, "One or more identifiers does not appear to be a DOI or uuid")
-    }
-    
-    if ("plos" %in% sources){
-      plos <- citation_search_plos(identifiers)
-    } else plos <- NULL
-  
-    if ("scopus" %in% sources){
-      scopus <- citation_search_scopus(identifiers)
-    } else scopus <- NULL
-  
-    if ("springer" %in% sources){
-      springer <- citation_search_springer(identifiers)
-    } else springer <- NULL
-  
-  result <- rbind(plos, scopus, springer)
+  # combine all of the resulting data frames and return the result df
+  bind_function <- paste0("rbind(", paste0(sources, collapse = ","), ")")
+  result <- eval(parse(text = bind_function))
+
   return(result)
 
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To set API keys for use in the package, see the section below on authentication.
 
 ```
 library(scythe)
-scythe_set_key(scopus_key = "SCOPUS KEY", springer_key = "SPRINGER KEY")
+scythe_set_key(source = "scopus", secret = "YOUR KEY")
 
 identifier <- "10.18739/A22274"
 results <- citation_search(identifier)
@@ -51,8 +51,8 @@ The function `scythe_set_key()` manages API keys using the [`keyring`](https://g
 To obtain a Scopus API key, make an account at the [Elseviers Developers Portal](https://dev.elsevier.com/) and create API key. Once you've obtained your key, you can use `scythe_set_key()` to securely set your key. This key is accessed in the `citation_search()` function, but you can also retrieve the value using `keyring::key_get()`.
 
 ```
-scythe_set_key(scopus_key = "YOUR_KEY")
-keyring::key_get("scopus_key", keyring = "scythe")
+scythe_set_key(source = "scopus", secret = "YOUR_KEY")
+keyring::key_get("scopus", keyring = "scythe")
 ```
 
 #### Springer
@@ -60,8 +60,8 @@ keyring::key_get("scopus_key", keyring = "scythe")
 The Springer Nature API key is available by creating an application [here](https://dev.springernature.com/admin/applications) after signing up for an account. The key can be set and retrieved using:
 
 ```
-scythe_set_key(springer_key = "YOUR_KEY")
-keyring::key_get("springer_key", keyring = "scythe")
+scythe_set_key(source = "springer", secret = "YOUR_KEY")
+keyring::key_get("springer", keyring = "scythe")
 ```
 
 ## Acknowledgments


### PR DESCRIPTION
- corrected readme
- reimplement Matt's method from c83fe5e with the bug fixed

@mbjones I liked your method and wanted to see why it wasn't working - turns out the bind function you created made a list that looked like:`rbind(source1), rbind(source2), rbind(source3)`, which was run sequentially and then just returned `source3`.

I corrected it so that it returns `rbind(source1, source2, source3)`

Your tests were passing since you didn't have any keys set (I'm guessing), so it was only running one source. GHA, which runs all of the sources, found the issue though.